### PR TITLE
feat: prevent spam

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,7 @@ jobs:
         uses: github/codeql-action/analyze@v1
 
       - uses: codecov/codecov-action@v2
-        with:
-          flags: api
+
   cd:
     name: CD
     needs: ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,5 +39,3 @@ jobs:
         uses: github/codeql-action/analyze@v1
 
       - uses: codecov/codecov-action@v2
-        with:
-          flags: api

--- a/logic/captcha_answer.go
+++ b/logic/captcha_answer.go
@@ -77,8 +77,14 @@ func (d *Dependencies) WaitForAnswer(m *tb.Message) {
 		return
 	}
 
+	// If the user submitted something that's a number but contains spaces,
+	// we will trim the spaces down. This is because I'm lazy to not let
+	// the user pass if they're actually answering the right answer
+	// but got spaces on their answer. You get the idea.
+	answer := removeSpaces(m.Text)
+
 	// Check if the answer is not a number
-	if _, err := strconv.Atoi(m.Text); errors.Is(err, strconv.ErrSyntax) {
+	if _, err := strconv.Atoi(answer); errors.Is(err, strconv.ErrSyntax) {
 		remainingTime := time.Until(captcha.Expiry)
 		wrongMsg, err := d.Bot.Send(
 			m.Chat,
@@ -101,7 +107,7 @@ func (d *Dependencies) WaitForAnswer(m *tb.Message) {
 	}
 
 	// Check if the answer is correct or not
-	if m.Text != captcha.Answer {
+	if answer != captcha.Answer {
 		remainingTime := time.Until(captcha.Expiry)
 		wrongMsg, err := d.Bot.Send(
 			m.Chat,
@@ -210,4 +216,10 @@ func collectAdditionalAndCache(cache *bigcache.BigCache, bot *tb.Bot, logger *se
 // Check if the message contains any media.
 func isMedia(m *tb.Message) bool {
 	return m.Text == ""
+}
+
+// Uh.. You should understand what this function does.
+// It's pretty self explanatory.
+func removeSpaces(text string) string {
+	return strings.ReplaceAll(text, " ", "")
 }

--- a/logic/captcha_answer.go
+++ b/logic/captcha_answer.go
@@ -66,7 +66,11 @@ func (d *Dependencies) WaitForAnswer(m *tb.Message) {
 			return
 		}
 
-		go deleteMessage(d.Bot, tb.StoredMessage{ChatID: m.Chat.ID, MessageID: strconv.Itoa(m.ID)})
+		err = d.Bot.Delete(m)
+		if err != nil {
+			handleError(err, d.Logger, d.Bot, m)
+			return
+		}
 
 		collectAdditionalAndCache(d.Cache, d.Bot, d.Logger, captcha, m, wrongMsg)
 

--- a/logic/captcha_answer.go
+++ b/logic/captcha_answer.go
@@ -52,18 +52,21 @@ func (d *Dependencies) WaitForAnswer(m *tb.Message) {
 		remainingTime := time.Until(captcha.Expiry)
 		wrongMsg, err := d.Bot.Send(
 			m.Chat,
-			"Selesain captchanya dulu yuk, baru kirim yang aneh-aneh. Kamu punya "+
+			"Hai, <a href=\"tg://user?id="+strconv.Itoa(m.Sender.ID)+
+				"\">"+m.Sender.FirstName+"</a>. "+
+				"Selesain captchanya dulu yuk, baru kirim yang aneh-aneh. Kamu punya "+
 				strconv.Itoa(int(remainingTime.Seconds()))+
 				" detik lagi, kalau nggak, saya kick!",
 			&tb.SendOptions{
 				ParseMode: tb.ModeHTML,
-				ReplyTo:   m,
 			},
 		)
 		if err != nil {
 			handleError(err, d.Logger, d.Bot, m)
 			return
 		}
+
+		go deleteMessage(d.Bot, tb.StoredMessage{ChatID: m.Chat.ID, MessageID: strconv.Itoa(m.ID)})
 
 		collectAdditionalAndCache(d.Cache, d.Bot, d.Logger, captcha, m, wrongMsg)
 


### PR DESCRIPTION
after sending the captcha, the bot will listen to the incoming message, right?

then it will check whether or not the user id is in the in-memory cache

if they are, check for the following conditions:
- if they send other things than plain text -> warn them to solve the captcha first, then delete their latest message
- if they send a plain text but not a number -> tell them that it's only a number
- if they send a plain text but a number -> goes into the captcha verification logic

also, I added a fix where in which the user leaves the group before finishing the captcha, it will delete all the message that has been sent before.