### PR TITLE
Fix: Random Selection Of Welcome Message

### DIFF
--- a/captcha/welcome.go
+++ b/captcha/welcome.go
@@ -91,5 +91,5 @@ func (d *Dependencies) sendWelcomeMessage(m *tb.Message) error {
 }
 
 func randomNum() int {
-	return rand.Intn(len(currentWelcomeMessages) - 1)
+	return rand.Intn(len(currentWelcomeMessages))
 }


### PR DESCRIPTION
Because `rand.Intn` already use half-open interval [0,n), which means greater than 0 and less than n so we can safely use length of welcome message.

## Reference:
rand.Intn : https://pkg.go.dev/math/rand#Intn
half-open-interval: https://en.wikipedia.org/wiki/Interval_(mathematics)#:~:text=A%20half%2Dopen%20interval%20includes,0%20and%20less%20than%201.